### PR TITLE
Export necessary identifiers for external collection

### DIFF
--- a/pkg/collector/labels.go
+++ b/pkg/collector/labels.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/usage-metrics-collector/pkg/sampler/api"
 )
 
-// labler parses labels from Kubernetes objects and sets them on Values
-type labler struct {
+// Labeler parses labels from Kubernetes objects and sets them on Values
+type Labeler struct {
 	// BuiltIn contains compiled in metric labels
 	BuiltIn builtInLabler
 	// Extension contains extension metric labels
@@ -31,55 +31,55 @@ type labler struct {
 }
 
 // SetLabelsForContainer parses metric labels from a container and pod
-func (l labler) SetLabelsForContainer(
-	labels *labelsValues, container *corev1.Container) {
+func (l Labeler) SetLabelsForContainer(
+	labels *LabelsValues, container *corev1.Container) {
 	l.BuiltIn.SetLabelsForContainer(&labels.BuiltIn, container)
 	// no extension labels for containers
 }
 
-func (l labler) SetLabelsForPod(
-	labels *labelsValues, pod *corev1.Pod, w workload,
+func (l Labeler) SetLabelsForPod(
+	labels *LabelsValues, pod *corev1.Pod, w workload,
 	node *corev1.Node, namespace *corev1.Namespace) {
 	l.BuiltIn.SetLabelsForPod(&labels.BuiltIn, pod, w, node, namespace)
 	l.Extension.SetLabelsForPod(&labels.Extension, pod, w, node, namespace)
 }
 
 // SetLabelsForNode parses metric labels from a node
-func (l labler) SetLabelsForNode(labels *labelsValues, node *corev1.Node) {
+func (l Labeler) SetLabelsForNode(labels *LabelsValues, node *corev1.Node) {
 	l.BuiltIn.SetLabelsForNode(&labels.BuiltIn, node)
 	l.Extension.SetLabelsForNode(&labels.Extension, node)
 }
 
-func (l labler) SetLabelsFoCGroup(labels *labelsValues, u *api.NodeAggregatedMetrics) {
+func (l Labeler) SetLabelsFoCGroup(labels *LabelsValues, u *api.NodeAggregatedMetrics) {
 	l.BuiltIn.SetLabelsForCGroup(&labels.BuiltIn, u)
 }
 
 // SetLabelsForQuota parses metric labels from a namespace
-func (l labler) SetLabelsForQuota(labels *labelsValues,
+func (l Labeler) SetLabelsForQuota(labels *LabelsValues,
 	quota *corev1.ResourceQuota, rqd *quotamanagementv1alpha1.ResourceQuotaDescriptor, namespace *corev1.Namespace) {
 	l.BuiltIn.SetLabelsForQuota(&labels.BuiltIn, quota, rqd, namespace)
 	l.Extension.SetLabelsForQuota(&labels.Extension, quota, rqd, namespace)
 }
 
 // SetLabelsForNamespace parses metric labels from a namespace
-func (l labler) SetLabelsForNamespaces(labels *labelsValues, namespace *corev1.Namespace) {
+func (l Labeler) SetLabelsForNamespaces(labels *LabelsValues, namespace *corev1.Namespace) {
 	l.BuiltIn.SetLabelsForNamespace(&labels.BuiltIn, namespace)
 	l.Extension.SetLabelsForNamespace(&labels.Extension, namespace)
 }
 
 // SetLabelsForPVCQuota set storage class label from resource and quota spec
-func (l labler) SetLabelsForPVCQuota(labels *labelsValues,
+func (l Labeler) SetLabelsForPVCQuota(labels *LabelsValues,
 	quota *corev1.ResourceQuota, resource string) {
 	l.BuiltIn.SetLabelsForPVCQuota(&labels.BuiltIn, quota, resource)
 }
 
-func (l labler) SetLabelsForPersistentVolume(labels *labelsValues,
+func (l Labeler) SetLabelsForPersistentVolume(labels *LabelsValues,
 	pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, node *corev1.Node) {
 	l.BuiltIn.SetLabelsForPersistentVolume(&labels.BuiltIn, pv, pvc, node)
 	l.Extension.SetLabelsForPersistentVolume(&labels.Extension, pv, pvc, node)
 }
 
-func (l labler) SetLabelsForPersistentVolumeClaim(labels *labelsValues,
+func (l Labeler) SetLabelsForPersistentVolumeClaim(labels *LabelsValues,
 	pvc *corev1.PersistentVolumeClaim,
 	pv *corev1.PersistentVolume, namespace *corev1.Namespace,
 	pod *corev1.Pod, w workload, node *corev1.Node) {
@@ -87,13 +87,13 @@ func (l labler) SetLabelsForPersistentVolumeClaim(labels *labelsValues,
 	l.Extension.SetLabelsForPersistentVolumeClaim(&labels.Extension, pvc, pv, namespace, pod, w, node)
 }
 
-func (l labler) SetLabelsForClusterScoped(labels *labelsValues, discoveredLabels map[string]string) {
+func (l Labeler) SetLabelsForClusterScoped(labels *LabelsValues, discoveredLabels map[string]string) {
 	l.BuiltIn.SetLabelsForClusterScoped(&labels.BuiltIn, discoveredLabels)
 	// TODO: extension labels
 }
 
-// labelsValues contains metric label values
-type labelsValues struct {
+// LabelsValues contains metric label values
+type LabelsValues struct {
 	BuiltIn builtInLabelsValues
 
 	Extension extensionLabelsValues
@@ -520,7 +520,7 @@ func (c *Collector) initInternalLabelsMask(mask *collectorcontrollerv1alpha1.Lab
 }
 
 // mask masks labels by clearing them
-func (c *Collector) mask(mask collectorcontrollerv1alpha1.LabelsMask, m labelsValues) labelsValues {
+func (c *Collector) mask(mask collectorcontrollerv1alpha1.LabelsMask, m LabelsValues) LabelsValues {
 	m.BuiltIn = builtInMask(mask.BuiltIn, m.BuiltIn)
 
 	// get the internal version that maps label names to fields
@@ -563,7 +563,7 @@ func overrideValues(values, names []string) {
 }
 
 // getLabelValues returns the set of label values for this mask
-func (c *Collector) getLabelValues(mask collectorcontrollerv1alpha1.LabelsMask, m labelsValues, names []string) []string {
+func (c *Collector) getLabelValues(mask collectorcontrollerv1alpha1.LabelsMask, m LabelsValues, names []string) []string {
 	if mask.BuiltIn.Level {
 		// set the level from the mask level name
 		m.BuiltIn.Level = mask.Level

--- a/pkg/collector/local.go
+++ b/pkg/collector/local.go
@@ -74,7 +74,7 @@ func (c *Collector) newSampleListBuilder(src string, createIfNoMatch bool) *Samp
 }
 
 // NewSample creates a new Sample for an object
-func (sb *SampleListBuilder) NewSample(labels labelsValues) *collectorapi.Sample {
+func (sb *SampleListBuilder) NewSample(labels LabelsValues) *collectorapi.Sample {
 	if sb == nil {
 		return nil
 	}

--- a/pkg/collector/metric.go
+++ b/pkg/collector/metric.go
@@ -27,15 +27,15 @@ type Metric struct {
 	// Mask contains the set of labels that apply to this metric
 	Mask collectorcontrollerv1alpha1.LabelsMask
 
-	Name metricName
+	Name MetricName
 
 	Buckets map[string][]float64
 
 	// Values contains the metric values for each unique set of labels
-	Values map[labelsValues][]resource.Quantity
+	Values map[LabelsValues][]resource.Quantity
 }
 
-type metricName struct {
+type MetricName struct {
 	Prefix string
 
 	Level string // e.g. cluster
@@ -51,7 +51,7 @@ type metricName struct {
 	SourceType string // e.g. quota
 }
 
-func (m metricName) String() string {
+func (m MetricName) String() string {
 	return strings.Join([]string{m.Prefix, m.Level, m.Operation, m.Source, m.ResourceAlias}, "_")
 }
 

--- a/pkg/collector/operations.go
+++ b/pkg/collector/operations.go
@@ -64,12 +64,12 @@ func aggregate(op collectorcontrollerv1alpha1.AggregationOperation, values quant
 func (c *Collector) aggregateMetric(op collectorcontrollerv1alpha1.AggregationOperation, m Metric, mask collectorcontrollerv1alpha1.LabelsMask) Metric {
 	result := Metric{
 		Mask:   mask,
-		Values: map[labelsValues][]resource.Quantity{},
+		Values: map[LabelsValues][]resource.Quantity{},
 	}
 
 	// map the values so they are mappedValues by the new level rather than the old
 	// e.g. map multiple "containers" in the same "pod" to that "pod" key
-	indexed := map[labelsValues][]resource.Quantity{}
+	indexed := map[LabelsValues][]resource.Quantity{}
 	for k, v := range m.Values {
 		// apply the mask to get the new key of the aggregated value and add to that slice
 		labels := c.mask(mask, k)

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -34,7 +34,7 @@ func (c *Collector) init() error {
 		return err
 	}
 	c.sideCarConfigs = sccfg
-	c.labler.Extension.SideCar = sccfg
+	c.Labeler.Extension.SideCar = sccfg
 
 	// initialize internal IDs
 	var labelId int
@@ -96,8 +96,8 @@ func (c *Collector) init() error {
 		return err
 	}
 
-	c.labler.BuiltIn.UseQuotaNameForPriorityClass = c.BuiltIn.UseQuotaNameForPriorityClass
-	c.labler.Extension.Extensions = c.Extensions
+	c.Labeler.BuiltIn.UseQuotaNameForPriorityClass = c.BuiltIn.UseQuotaNameForPriorityClass
+	c.Labeler.Extension.Extensions = c.Extensions
 	return nil
 }
 

--- a/pkg/collector/values.go
+++ b/pkg/collector/values.go
@@ -35,8 +35,8 @@ type value struct {
 	Source            string                                      `json:"source" yaml:"source"`
 }
 
-// RequestsValueReader reads the requests value as a ResourceList
-type valueReader struct{}
+// ValueReader reads the requests value as a ResourceList
+type ValueReader struct{}
 
 // GetValuesForContainer returns the ResourceLists from a container for:
 // - requests_allocated
@@ -46,7 +46,7 @@ type valueReader struct{}
 // - nr_periods
 // - nr_throttled
 // - oom_kill
-func (r valueReader) GetValuesForContainer(
+func (r ValueReader) GetValuesForContainer(
 	container *corev1.Container, pod *corev1.Pod, usage *api.ContainerMetrics) map[string]value {
 	values := map[string]value{}
 
@@ -185,7 +185,7 @@ func createValue(pod *corev1.Pod, usage []int64, source, resName string) value {
 	return val
 }
 
-func (r valueReader) GetValuesForPod(pod *corev1.Pod) map[string]value {
+func (r ValueReader) GetValuesForPod(pod *corev1.Pod) map[string]value {
 	count := value{
 		ResourceList: map[corev1.ResourceName]resource.Quantity{
 			collectorcontrollerv1alpha1.ItemsResource: *resource.NewQuantity(1, resource.DecimalSI),
@@ -218,7 +218,7 @@ var now = func() time.Time {
 }
 
 // GetValuesForQuota returns the ResourceLists from a namespace quota
-func (r valueReader) GetValuesForQuota(quota *corev1.ResourceQuota, rqd *quotamanagementv1alpha1.ResourceQuotaDescriptor, enableRqd bool) map[string]value {
+func (r ValueReader) GetValuesForQuota(quota *corev1.ResourceQuota, rqd *quotamanagementv1alpha1.ResourceQuotaDescriptor, enableRqd bool) map[string]value {
 	requestsHard := value{
 		Level:  collectorcontrollerv1alpha1.NamespaceLevel,
 		Source: collectorcontrollerv1alpha1.QuotaRequestsHardSource,
@@ -473,7 +473,7 @@ func getMaxObservedQuota(rqd *quotamanagementv1alpha1.ResourceQuotaDescriptor) (
 }
 
 // GetValuesForNode returns the metric values for a Node.  pods is the Pods scheduled to this Node.
-func (r valueReader) GetValuesForNode(node *corev1.Node, pods []*corev1.Pod) map[string]value {
+func (r ValueReader) GetValuesForNode(node *corev1.Node, pods []*corev1.Pod) map[string]value {
 	allocatable := value{
 		ResourceList: node.Status.Allocatable,
 		Level:        collectorcontrollerv1alpha1.NodeLevel,
@@ -518,7 +518,7 @@ func (r valueReader) GetValuesForNode(node *corev1.Node, pods []*corev1.Pod) map
 		collectorcontrollerv1alpha1.NodeAllocatableMinusRequests: allocatableMinusRequests}
 }
 
-func (r valueReader) GetValuesForPVC(pvc *corev1.PersistentVolumeClaim) map[string]value {
+func (r ValueReader) GetValuesForPVC(pvc *corev1.PersistentVolumeClaim) map[string]value {
 	requests := value{
 		ResourceList: pvc.Spec.Resources.Requests,
 		Level:        collectorcontrollerv1alpha1.PVCLevel,
@@ -550,7 +550,7 @@ func (r valueReader) GetValuesForPVC(pvc *corev1.PersistentVolumeClaim) map[stri
 	}
 }
 
-func (r valueReader) GetValuesForPV(pv *corev1.PersistentVolume) map[string]value {
+func (r ValueReader) GetValuesForPV(pv *corev1.PersistentVolume) map[string]value {
 	capacity := value{
 		ResourceList: pv.Spec.Capacity,
 		Level:        collectorcontrollerv1alpha1.PVLevel,


### PR DESCRIPTION
PR #37  added the capacity to add collection functions.

This PR exposes the necessary API for these external collection functions to perform their tasks.

In addition to exporting all of these identifiers, we are renaming the `collector.Collector` field previously named `labler` to `Labeler`.