### PR TITLE
Add concurrency to collection and aggregation

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -688,9 +688,17 @@ func (c *Collector) collectCGroups(o *CapacityObjects, ch chan<- prometheus.Metr
 		log.Error(err, "unable to save metrics locally")
 	}
 
+	// aggregate all cgroup sources concurrently
+	wg := &sync.WaitGroup{}
 	for _, a := range c.MetricsPrometheusCollector.Aggregations.ByType(collectorcontrollerv1alpha1.CGroupType) {
-		c.AggregateAndCollect(a, metrics, ch, sCh)
+		wg.Add(1)
+		go func (agg *collectorcontrollerv1alpha1.Aggregation) {
+			c.AggregateAndCollect(agg, metrics, ch, sCh)
+			wg.Done()
+		} (a)
 	}
+	wg.Wait()
+
 	resultMetric.Collect(ch)
 	return nil
 }
@@ -1013,9 +1021,17 @@ func (c *Collector) collectContainers(o *CapacityObjects, ch chan<- prometheus.M
 		log.Error(err, "unable to save metrics locally")
 	}
 
+	// aggregate all container sources concurrently
+	wg := &sync.WaitGroup{}
 	for _, a := range c.MetricsPrometheusCollector.Aggregations.ByType(collectorcontrollerv1alpha1.ContainerType) {
-		c.AggregateAndCollect(a, containerMetrics, ch, sCh)
+		wg.Add(1)
+		go func(agg *collectorcontrollerv1alpha1.Aggregation) {
+			c.AggregateAndCollect(agg, containerMetrics, ch, sCh)
+			wg.Done()
+		} (a)
 	}
+	wg.Wait()
+
 	for _, a := range c.MetricsPrometheusCollector.Aggregations.ByType(collectorcontrollerv1alpha1.PodType) {
 		c.AggregateAndCollect(a, podMetrics, ch, sCh)
 	}

--- a/pkg/collector/operations.go
+++ b/pkg/collector/operations.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"math"
 	"sort"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/usage-metrics-collector/pkg/api/collectorcontrollerv1alpha1"
@@ -105,9 +106,20 @@ func (c *Collector) aggregateMetric(op collectorcontrollerv1alpha1.AggregationOp
 		}
 	}
 
+	// do metric values aggregation concurrently
+	wg := &sync.WaitGroup{}
+	mu := &sync.Mutex{}
 	// reduce by applying the aggregation operation to each slice
 	for k := range indexed {
-		result.Values[k] = aggregate(op, indexed[k])
+		wg.Add(1)
+		go func(lVals LabelsValues) {
+			qty := aggregate(op, indexed[lVals])
+			mu.Lock()
+			result.Values[lVals] = qty
+			mu.Unlock()
+			wg.Done()
+		}(k)
 	}
+	wg.Wait()
 	return result
 }


### PR DESCRIPTION
- Collection time for Containers and Cgroups was taking very long due to high cardinality. This PR adds concurrency to the collection of container and cgroup sources. 
- Concurrency was also added to aggregation  of metrics at each level