### PR TITLE
Revert "Use channel for aggregation operation"

### DIFF
--- a/pkg/collector/operations.go
+++ b/pkg/collector/operations.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"math"
 	"sort"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/usage-metrics-collector/pkg/api/collectorcontrollerv1alpha1"
@@ -122,32 +123,28 @@ func (c *Collector) aggregateMetric(ops []collectorcontrollerv1alpha1.Aggregatio
 		}
 	}
 
-	l := len(ops)
-	resChan := make(chan map[collectorcontrollerv1alpha1.AggregationOperation]*Metric, l)
-	defer close(resChan)
+	wg := &sync.WaitGroup{}
+	mu := &sync.Mutex{}
 	for _, op := range ops {
+		res := &Metric{
+			Mask:   mask,
+			Values: map[LabelsValues][]resource.Quantity{},
+		}
+		wg.Add(1)
 		go func(o collectorcontrollerv1alpha1.AggregationOperation) {
 			// calculate the operations in parallel
 			// reduce by applying the aggregation operation to each slice
-			res := map[collectorcontrollerv1alpha1.AggregationOperation]*Metric{
-				o: {
-					Mask:   mask,
-					Values: map[LabelsValues][]resource.Quantity{},
-				},
-			}
 			for k := range indexed {
-				res[o].Values[k] = aggregate(o, indexed[k], sorted)
+				// go routine with wait group
+				res.Values[k] = aggregate(o, indexed[k], sorted)
 			}
-			resChan <- res
+			mu.Lock()
+			results[o] = res
+			mu.Unlock()
+			wg.Done()
 		}(op)
 	}
-
-	// get results from channel
-	for i := 0; i < l; i++ {
-		for k, v := range <-resChan {
-			results[k] = v
-		}
-	}
+	wg.Wait()
 
 	return results
 }


### PR DESCRIPTION
Reverts kubernetes-sigs/usage-metrics-collector#46