### PR TITLE
Parse total_rss and total_cache for cgroup memory samples

### DIFF
--- a/cmd/metrics-node-sampler/integration/integration_test.go
+++ b/cmd/metrics-node-sampler/integration/integration_test.go
@@ -210,8 +210,8 @@ type fakeFS struct {
 }
 
 type MemorySample struct {
-	RSS   int `yaml:"rss" json:"rss"`
-	Cache int `yaml:"cache" json:"cache"`
+	RSS   int `yaml:"total_rss" json:"total_rss"`
+	Cache int `yaml:"total_cache" json:"total_cache"`
 }
 
 type MemoryOOMKillSample struct {
@@ -247,7 +247,7 @@ func (fakeFS *fakeFS) Open(name string) (fs.File, error) {
 		index := fakeFS.index[name] % len(val)
 		fakeFS.index[name] = (index + 1)
 		newVal := val[index]
-		b := fmt.Sprintf("cache %d\nrss %d\n", newVal.Cache, newVal.RSS)
+		b := fmt.Sprintf("total_cache %d\ntotal_rss %d\n", newVal.Cache, newVal.RSS)
 		err := os.WriteFile(filepath.Join(fakeFS.root, name), []byte(b), 0600)
 		if err != nil {
 			return nil, err

--- a/cmd/metrics-node-sampler/integration/testdata/input_samples.yaml
+++ b/cmd/metrics-node-sampler/integration/testdata/input_samples.yaml
@@ -74,49 +74,49 @@ cpuThrottlingSamples:
     nr_throttled: 500
 memorySamples:
   "sys/fs/cgroup/memory/system.slice/kubelet.service/memory.stat":
-  - rss: 100
-    cache: 50
-  - rss: 200
-    cache: 100
-  - rss: 300
-    cache: 300
-  - rss: 400
-    cache: 400
-  - rss: 500
-    cache: 500
+  - total_rss: 100
+    total_cache: 50
+  - total_rss: 200
+    total_cache: 100
+  - total_rss: 300
+    total_cache: 300
+  - total_rss: 400
+    total_cache: 400
+  - total_rss: 500
+    total_cache: 500
   "sys/fs/cgroup/memory/kubelet/kubepods/memory.stat":
-  - rss: 100
-    cache: 50
-  - rss: 200
-    cache: 100
-  - rss: 300
-    cache: 300
-  - rss: 400
-    cache: 400
-  - rss: 500
-    cache: 500
+  - total_rss: 100
+    total_cache: 50
+  - total_rss: 200
+    total_cache: 100
+  - total_rss: 300
+    total_cache: 300
+  - total_rss: 400
+    total_cache: 400
+  - total_rss: 500
+    total_cache: 500
   "sys/fs/cgroup/memory/kubelet/kubepods/guaranteed/memory.stat":
-  - rss: 50
-    cache: 50
-  - rss: 50
-    cache: 50
-  - rss: 50
-    cache: 100
-  - rss: 60
-    cache: 110
-  - rss: 100
-    cache: 200
+  - total_rss: 50
+    total_cache: 50
+  - total_rss: 50
+    total_cache: 50
+  - total_rss: 50
+    total_cache: 100
+  - total_rss: 60
+    total_cache: 110
+  - total_rss: 100
+    total_cache: 200
   "sys/fs/cgroup/memory/kubelet/kubepods/burstable/podpod12345/abcdef/memory.stat":
-  - rss: 100
-    cache: 110
-  - rss: 100
-    cache: 150
-  - rss: 200
-    cache: 120
-  - rss: 200
-    cache: 140
-  - rss: 300
-    cache: 130
+  - total_rss: 100
+    total_cache: 110
+  - total_rss: 100
+    total_cache: 150
+  - total_rss: 200
+    total_cache: 120
+  - total_rss: 200
+    total_cache: 140
+  - total_rss: 300
+    total_cache: 130
 oomSamples:
   "sys/fs/cgroup/memory/kubelet/kubepods/burstable/podpod12345/abcdef/memory.oom_control":
   - "oom_kill": 0

--- a/pkg/api/samplerserverv1alpha1/doc.go
+++ b/pkg/api/samplerserverv1alpha1/doc.go
@@ -41,8 +41,8 @@
 //	  nr_throttled – number of runnable periods in which the application used its entire quota and was throttled
 //	  throttled_time – sum total amount of time individual threads within the cgroup were throttled
 //	memory.stat:
-//	  cache : The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.
-//	  rss : The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.
+//	  total_cache : The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device.
+//	  total_rss : The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps.
 //	oom_control:
 //	  oom-kill : OOM Kill counter
 //	  memory.failcnt: reports the number of times that the memory limit has reached the value set in memory.limit_in_bytes.

--- a/pkg/sampler/cgroup.go
+++ b/pkg/sampler/cgroup.go
@@ -234,9 +234,9 @@ func (r *metricsReader) GetLevelMemoryMetrics(metricFilepaths map[ContainerMetri
 				switch metricType {
 				case MemoryUsageMetricType:
 					switch fields[0] {
-					case "rss":
+					case "total_rss":
 						metrics.RSS = value
-					case "cache":
+					case "total_cache":
 						metrics.Cache = value
 					}
 				case MemoryOOMKillMetricType:


### PR DESCRIPTION
Since the move to containerd sockets, the right field to parse for memory samples that include root and children usage is not `rss` and `cache` anymore.

This PR fixes it to parse `total_rss` and `total_cache` instead.

I am not renaming the fields to minimize changes.