### PR TITLE
Fix check on checkCreatedPodFrequency

### DIFF
--- a/pkg/sampler/server.go
+++ b/pkg/sampler/server.go
@@ -122,8 +122,8 @@ func (s *Server) Start(ctx context.Context, stop context.CancelFunc) error {
 	if err != nil {
 		return err
 	}
-	if s.pushFrequency < time.Second {
-		return errors.New("pushFrequencyDuration must be at least 1 seconds")
+	if s.checkCreatedPodFrequency < time.Second {
+		return errors.New("checkCreatedPodFrequency must be at least 1 seconds")
 	}
 
 	errs := make(chan error)


### PR DESCRIPTION
This check was previously doing a pointless check on pushFrequency, assuming that was a copy/paste mistake.