### PR TITLE
Expose pprof endpoints on metrics-node-sampler

### DIFF
--- a/cmd/metrics-node-sampler/cmd/cmd.go
+++ b/cmd/metrics-node-sampler/cmd/cmd.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
+	_ "net/http/pprof"
+
 	commonlog "sigs.k8s.io/usage-metrics-collector/pkg/log"
 	"sigs.k8s.io/usage-metrics-collector/pkg/sampler"
 	"sigs.k8s.io/usage-metrics-collector/pkg/watchconfig"

--- a/pkg/sampler/server.go
+++ b/pkg/sampler/server.go
@@ -187,8 +187,13 @@ func (s *Server) Start(ctx context.Context, stop context.CancelFunc) error {
 		return err
 	}
 
+	// Serve the API under /v1 but also expose pprof endpoints.
+	mux := http.NewServeMux()
+	mux.Handle("/v1/", gwmux)
+	mux.Handle("/", http.DefaultServeMux)
+
 	addr := fmt.Sprintf(":%v", s.RestPort)
-	gwServer := &http.Server{Addr: addr, Handler: gwmux}
+	gwServer := &http.Server{Addr: addr, Handler: mux}
 	rpcServer := grpc.NewServer()
 	api.RegisterMetricsServer(rpcServer, s)
 	api.RegisterHealthServer(rpcServer, s)


### PR DESCRIPTION
This exposes `/debug/pprof/$PROFILE` endpoints for each pprof profile.

Exposing these endpoints does not have any effect on the performance of the node sampler,
so there's no need for flags to switch this behavior on/off.