### PR TITLE
Stop parsing container annotations, extract info from labels

### DIFF
--- a/cmd/container-monitor/cmd/cmd.go
+++ b/cmd/container-monitor/cmd/cmd.go
@@ -124,29 +124,12 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 
 	wg := &sync.WaitGroup{}
 	for _, c := range containers {
-
-		// If ContainerID and SandboxID are the same, we are either dealing with a
-		// single container (non pod), or a pause container
-		if c.ContainerID == c.SandboxID {
-
-			// If a Pod ID is available, we know that this is a pod and should skip
-			// stats gathering:
-			if c.PodID != "" {
-				monitorLog.WithField("container id", c.ContainerID).Trace("skipping stats collection for pause container")
-				continue
-			}
-
-			monitorLog.WithField("container id", c.ContainerID).Trace("standlone container observed")
-			c.ContainerName = c.ContainerID
-		}
-
 		wg.Add(1)
 
 		go func(c ctrstats.Container, results chan<- prometheus.Metric) {
 			stats, err := ctrstats.GetContainerStats(context.Background(), c)
 			if err != nil {
 				monitorLog.WithFields(log.Fields{
-					"sandbox":   c.SandboxID,
 					"container": c.ContainerID,
 				}).WithError(err).Info("failed to get container stats - likely an issue with non-running containers being tracked in containerd state")
 			} else if stats != nil {

--- a/cmd/metrics-node-sampler/cmd/cmd_linux_amd64.go
+++ b/cmd/metrics-node-sampler/cmd/cmd_linux_amd64.go
@@ -121,29 +121,12 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 
 	wg := &sync.WaitGroup{}
 	for _, c := range containers {
-
-		// If ContainerID and SandboxID are the same, we are either dealing with a
-		// single container (non pod), or a pause container
-		if c.ContainerID == c.SandboxID {
-
-			// If a Pod ID is available, we know that this is a pod and should skip
-			// stats gathering:
-			if c.PodID != "" {
-				monitorLog.WithField("container id", c.ContainerID).Trace("skipping stats collection for pause container")
-				continue
-			}
-
-			monitorLog.WithField("container id", c.ContainerID).Trace("standlone container observed")
-			c.ContainerName = c.ContainerID
-		}
-
 		wg.Add(1)
 
 		go func(c ctrstats.Container, results chan<- prometheus.Metric) {
 			stats, err := ctrstats.GetContainerStats(context.Background(), c)
 			if err != nil {
 				monitorLog.WithFields(logrus.Fields{
-					"sandbox":   c.SandboxID,
 					"container": c.ContainerID,
 				}).WithError(err).Info("failed to get container stats - likely an issue with non-running containers being tracked in containerd state")
 			} else if stats != nil {

--- a/pkg/sampler/ctrstats_linux_amd64.go
+++ b/pkg/sampler/ctrstats_linux_amd64.go
@@ -41,28 +41,11 @@ func (s *sampleCache) getContainerCPUAndMemoryCM() (cpuMetrics, memoryMetrics, e
 	knownPods := sets.NewString()
 
 	for _, c := range containers {
-
-		// If ContainerID and SandboxID are the same, we are either dealing with a
-		// single container (non pod), or a pause container
-		if c.ContainerID == c.SandboxID {
-
-			// If a Pod ID is available, we know that this is a pod and should skip
-			// stats gathering:
-			if c.PodID != "" {
-				log.V(7).Info("skipping stats collection for pause container", "container id", c.ContainerID)
-				continue
-			}
-
-			log.V(7).Info("standlone container observed", "container id", c.ContainerID)
-			c.ContainerName = c.ContainerID
-		}
-
 		// TODO: is this a reasonable key for the metric read time?
 		readTime := s.metricsReader.readTimeFunc(c.PodID + "/" + c.ContainerID)
 		stats, err := ctrstats.GetContainerStats(context.Background(), c)
 		if err != nil {
 			log.V(10).WithValues(
-				"sandbox", c.SandboxID,
 				"container", c.ContainerID,
 			).Info("failed to get container stats - likely an issue with non-running containers being tracked in containerd state", "err", err)
 		} else if stats != nil {


### PR DESCRIPTION
This PR makes it so the namespace value will be parsed from labels.
The sandboxID field will not be parsed anymore.

This should have a large impact on the performance of the sampler according to the pprof analyses performed.

It would remove the need to call `typeurl.UnmarshalAny` in the flame graph below:

<img width="1637" alt="Screenshot 2023-04-26 at 2 00 12 PM" src="https://user-images.githubusercontent.com/2237452/234701213-e76ee389-66ed-4976-9fcc-83a1272e48a8.png">


