### PR TITLE
Populate sidecar metrics when during collection

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -308,7 +308,12 @@ func (c *Collector) collect(ch chan<- prometheus.Metric, sCh chan *collectorapi.
 		log.Error(err, "failed to collect container metrics")
 	}
 
-	for _, sc := range c.sideCarConfigs {
+	sccfg, err := c.getSideCarConfigs()
+	if err != nil {
+		log.Error(err, "failed to collect sidecar metrics")
+	}
+
+	for _, sc := range sccfg {
 		for _, m := range sc.SideCarMetrics {
 			if m.Help == "" {
 				m.Help = c.Prefix + "_" + m.Name


### PR DESCRIPTION
Side car metrics are only currently only populated when collector is initialize. This re-poupulates the metrics during collect loop. 