### PR TITLE
Set loggers for controller runtime

### DIFF
--- a/cmd/metrics-node-sampler/cmd/cmd.go
+++ b/cmd/metrics-node-sampler/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	commonlog "sigs.k8s.io/usage-metrics-collector/pkg/log"
 	"sigs.k8s.io/usage-metrics-collector/pkg/sampler"
 	"sigs.k8s.io/usage-metrics-collector/pkg/watchconfig"
@@ -122,6 +123,9 @@ func init() {
 	RootCmd.Flags().IntVar(&terminationSeconds, "termination-seconds", 10, "time to wait for shutdown before os.Exit is called")
 	RootCmd.Flags().StringVar(&S.hostNameFilepath, "host-name-filepath", "", "DNS resolvable kubelet host name if different from the NODE_NAME")
 	RootCmd.Flags().AddGoFlagSet(flag.CommandLine)
+
+	// initialize controller runtime logger
+	runtimelog.SetLogger(log)
 
 	initContainerMonitor(RootCmd)
 }

--- a/cmd/metrics-prometheus-collector/cmd/cmd.go
+++ b/cmd/metrics-prometheus-collector/cmd/cmd.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/retry"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	quotamangementv1alpha1 "sigs.k8s.io/usage-metrics-collector/pkg/api/quotamanagementv1alpha1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,6 +61,9 @@ import (
 func init() {
 	_ = metricsv1beta1.AddToScheme(scheme.Scheme)
 	_ = quotamangementv1alpha1.AddToScheme(scheme.Scheme)
+
+	// initialize controller runtime logger
+	runtimelog.SetLogger(log)
 }
 
 var (

--- a/cmd/umc-archiver/cmds/main.go
+++ b/cmd/umc-archiver/cmds/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/api/option"
 	"k8s.io/apimachinery/pkg/util/sets"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/usage-metrics-collector/pkg/collector"
 	commonlog "sigs.k8s.io/usage-metrics-collector/pkg/log"
 )
@@ -74,6 +75,9 @@ func init() {
 	RootCmd.Flags().IntSliceVar(&options.gcsKeepFolderParts, "gcs-keep-folder-parts", []int{}, "keep these parts of the file directory.")
 	RootCmd.Flags().StringVar(&options.gcsFolder, "gcs-folder", "", "gcs folder to put files into.  note: may be templatized with the time.")
 	RootCmd.Flags().StringVar(&options.gcsBucket, "gcs-bucket", "", "gcs bucket.")
+
+	// initialize controller runtime logger
+	runtimelog.SetLogger(log)
 }
 
 var (


### PR DESCRIPTION
Started by seeing a lot of controller restarts:
```
metrics-prometheus-collector-7cc6f6bb96-5267w   2/3     CrashLoopBackOff   1580 (2m18s ago)   10d 
```

Next saw these logs right before the controller restarted. Of note is the function `engageStopProcedure` and the context being cancelled:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 6887 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.6/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc0001cba80, 0x0)
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.6/pkg/log/deleg.go:111 +0x32
	>  github.com/go-logr/logr.Logger.Enabled(...)
	>  	/go/pkg/mod/github.com/go-logr/logr@v1.2.4/logr.go:261
	>  github.com/go-logr/logr.Logger.Info({{0x24688b8?, 0xc0001cba80?}, 0xc000e89980?}, {0x1ee518d, 0x36}, {0x0, 0x0, 0x0})
	>  	/go/pkg/mod/github.com/go-logr/logr@v1.2.4/logr.go:274 +0x6e
	>  sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func3()
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.6/pkg/manager/internal.go:534 +0x53
	>  created by sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure in goroutine 1
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.6/pkg/manager/internal.go:532 +0x24a
{"level":"info","ts":"2025-01-15T22:39:56Z","logger":"usage-metrics-collector.collector","msg":"ending sampler server","reason":"context canceled"}
```

Reading the documentation: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log
```
This package contains a root logr.Logger Log. It may be used to get a handle to whatever the root logging implementation is. By default, no implementation exists, and the handle returns "promises" to loggers. When the implementation is set using SetLogger, these "promises" will be converted over to real loggers.
```
