### PR TITLE
Fix http superfluous call log messages

### DIFF
--- a/cmd/metrics-prometheus-collector/cmd/cmd.go
+++ b/cmd/metrics-prometheus-collector/cmd/cmd.go
@@ -433,7 +433,6 @@ func (ms *MetricsServer) serveMetricsFromCache() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
 	})
 	if err := http.ListenAndServe(options.externalBindAddress, nil); err != nil {
 		log.Error(err, "failed to listen on cached metrics address")


### PR DESCRIPTION
We are seeing a lot of log messages like this:

```
http: superfluous response.WriteHeader call from sigs.k8s.io/usage-metrics-collector/cmd/metrics-prometheus-collector/cmd.(*MetricsServer).serveMetricsFromCache.func1 (cmd.go:432)
```

This is caused by calling `WriteHeader()` after calling `Write()` which internally already calls `WriteHeader()` - https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/net/http/server.go;l=374

This functionality is present at least since Go version 1.19 https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/net/http/server.go;l=1147

A test exists as part of the standard library in https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/net/http/clientserver_test.go;l=1494
