### PR TITLE
Bump envtest-bin to 1.32.0 and update the download link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(TOOLS_DIR):
 	mkdir -p $(TOOLS_DIR) && cd $(TOOLS_DIR) && go mod init tempmod
 
 # We are using Kubebuilder Test Assets for integration testing
-K8S_VERSION=1.28.3
+K8S_VERSION=1.32.0
 KUBEBUILDER := $(abspath $(TOOLS_DIR)/kubebuilder)
 export KUBEBUILDER_ASSETS := $(KUBEBUILDER)/bin
 
@@ -116,7 +116,7 @@ proto: protoc
 
 
 $(KUBEBUILDER_ASSETS):
-	curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(K8S_VERSION)-$(GOOS)-amd64.tar.gz"
+	curl -sSLo envtest-bins.tar.gz "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v$(K8S_VERSION)/envtest-v$(K8S_VERSION)-$(GOOS)-amd64.tar.gz"
 	mkdir -p $(KUBEBUILDER)
 	tar -C $(KUBEBUILDER) --strip-components=1 -zvxf envtest-bins.tar.gz
 	rm envtest-bins.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(TOOLS_DIR):
 # We are using Kubebuilder Test Assets for integration testing
 K8S_VERSION=1.32.0
 KUBEBUILDER := $(abspath $(TOOLS_DIR)/kubebuilder)
-export KUBEBUILDER_ASSETS := $(KUBEBUILDER)/bin
+export KUBEBUILDER_ASSETS := $(KUBEBUILDER)/envtest
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= crd


### PR DESCRIPTION
/kind failing-test

Fixed #150

FYI https://github.com/kubernetes-sigs/kubebuilder/discussions/4082

https://testgrid.k8s.io/sig-instrumentation-usage-metrics-collector#periodic-test